### PR TITLE
Resolves a bug with update sequence

### DIFF
--- a/sync_fixtures.py
+++ b/sync_fixtures.py
@@ -160,9 +160,13 @@ def update_sequences():
     app = get_app('sentry')
     models = get_models(app, include_auto_created=True)
     statements = connection.ops.sequence_reset_sql(no_style(), models)
-    with connection.cursor() as cursor:
-        for sql in sequence_sql:
+    cursor = connection.cursor()
+    try:
+        for sql in statements:
             cursor.execute(sql)
+        connection.commit()
+    finally:
+        cursor.close()
 
 def main():
     print('Loading Fixtures...')

--- a/sync_fixtures.py
+++ b/sync_fixtures.py
@@ -1,4 +1,7 @@
 from urlparse import urlsplit
+from django.db import connection
+from django.db.models import get_app, get_models
+from django.core.management.color import no_style
 
 import sys
 import yaml
@@ -153,6 +156,13 @@ def parse(filename):
                 print('Error in team: {}, project: {} - {}'.format(team_name, project_name, error))
     return admin_details, projects, without_errors
 
+def update_sequences():
+    app = get_app('sentry')
+    models = get_models(app, include_auto_created=True)
+    statements = connection.ops.sequence_reset_sql(no_style(), models)
+    with connection.cursor() as cursor:
+        for sql in sequence_sql:
+            cursor.execute(sql)
 
 def main():
     print('Loading Fixtures...')
@@ -185,6 +195,10 @@ def main():
             sync_project_key(project_info['public_key'], project_info['private_key'], project_id)
         except Exception as error:
             print('Skipping team: {}, project: {} - {}'.format(team_name, project_name, error))
+
+    print('Updating sequences...')
+    update_sequences()
+
     print('Sync completed')
 
 


### PR DESCRIPTION
Currently when some projects are added from the configuration, as one mentions the project id of the project, so the records are inserted by id and auto increment is not updated.
When after the sentry is launchd if someone tries to create a new project then it throws error, the fix here updates auto increment of all the tables after the syncing of records complete.